### PR TITLE
support "WAVES" asset id as Waves in json serialization

### DIFF
--- a/src/main/java/im/mak/waves/transactions/common/AssetId.java
+++ b/src/main/java/im/mak/waves/transactions/common/AssetId.java
@@ -2,10 +2,14 @@ package im.mak.waves.transactions.common;
 
 import im.mak.waves.crypto.Bytes;
 
+import java.util.Locale;
+
 public class AssetId extends Id {
 
     public static final int BYTE_LENGTH = 32;
     public static final AssetId WAVES = new AssetId("");
+
+    private static final String WAVES_STRING = "WAVES";
 
     public AssetId(byte[] id) {
         super(id);
@@ -20,7 +24,7 @@ public class AssetId extends Id {
     }
 
     public static AssetId as(String id) {
-        return new AssetId(id);
+        return new AssetId(id == null || id.toUpperCase(Locale.ENGLISH).equals(WAVES_STRING) ? "" : id);
     }
 
     public boolean isWaves() {
@@ -29,6 +33,6 @@ public class AssetId extends Id {
 
     @Override
     public String toString() {
-        return isWaves() ? "WAVES" : encoded();
+        return isWaves() ? WAVES_STRING : encoded();
     }
 }


### PR DESCRIPTION
Accept JSON field `"assetId": "WAVES"` as Waves token.